### PR TITLE
v1.4.4

### DIFF
--- a/gmt-mailchimp.php
+++ b/gmt-mailchimp.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://github.com/cferdinandi/gmt-mailchimp/
  * GitHub Plugin URI: https://github.com/cferdinandi/gmt-mailchimp/
  * Description: MailChimp integration for WordPress
- * Version: 1.4.3
+ * Version: 1.4.4
  * Author: Chris Ferdinandi
  * Author URI: http://gomakethings.com
  * License: MIT

--- a/includes/mailchimp.php
+++ b/includes/mailchimp.php
@@ -161,7 +161,7 @@
 		}
 
 		// If email is invalid
-		if ( !is_email( $_POST['mailchimp_email'] ) ) {
+		if ( empty( filter_var( $_POST['mailchimp_email'], FILTER_VALIDATE_EMAIL ) ) ) {
 			mailchimp_set_session( 'mailchimp_status', $details['alert_bad_email'], 'post' );
 			mailchimp_set_session( 'mailchimp_email', $_POST['mailchimp_email'], 'post' );
 			wp_safe_redirect( $status, 302 );


### PR DESCRIPTION
Switched from `is_email` to `FILTER_VALIDATE_EMAIL`. The former does not properly support international domains.
